### PR TITLE
Add wrapper for call transcripts by id

### DIFF
--- a/src/endpoints/call-transcripts-by-id.ts
+++ b/src/endpoints/call-transcripts-by-id.ts
@@ -1,0 +1,31 @@
+import { request } from '../request'
+import type { paths } from '../sdk'
+
+export type GetCallTranscriptResponse =
+  paths['/v1/call-transcripts/{id}']['get']['responses']['200']['content']['application/json']
+
+export async function getCallTranscript(id: string) {
+  return request(
+    `/v1/call-transcripts/${id}` as `/v1/call-transcripts/{id}`,
+    'get'
+  )
+}
+
+export type UpdateCallTranscriptResponse = unknown
+
+export async function updateCallTranscript(id: string, body: unknown): Promise<UpdateCallTranscriptResponse> {
+  return request(
+    `/v1/call-transcripts/${id}` as unknown as `/v1/call-transcripts/{id}`,
+    'patch',
+    { body } as any
+  ) as unknown as UpdateCallTranscriptResponse
+}
+
+export type DeleteCallTranscriptResponse = unknown
+
+export async function deleteCallTranscript(id: string): Promise<DeleteCallTranscriptResponse> {
+  return request(
+    `/v1/call-transcripts/${id}` as unknown as `/v1/call-transcripts/{id}`,
+    'delete'
+  ) as unknown as DeleteCallTranscriptResponse
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,12 @@ export {
   UpdateCallRecordingResponse,
   DeleteCallRecordingResponse,
 } from './endpoints/call-recordings-by-id'
+
+export {
+  getCallTranscript,
+  updateCallTranscript,
+  deleteCallTranscript,
+  GetCallTranscriptResponse,
+  UpdateCallTranscriptResponse,
+  DeleteCallTranscriptResponse,
+} from './endpoints/call-transcripts-by-id'

--- a/tests/call-transcripts-by-id.test.ts
+++ b/tests/call-transcripts-by-id.test.ts
@@ -1,0 +1,64 @@
+import { afterAll, afterEach, beforeAll, expect, test } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+
+const BASE = 'https://api.openphone.com'
+const API_KEY = 'test-key'
+process.env.OPENPHONE_BASE_URL = BASE
+process.env.OPENPHONE_API_KEY = API_KEY
+
+const server = setupServer()
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+test('getCallTranscript sends correct request', async () => {
+  const id = 'call1'
+  const mock = { data: {} }
+
+  server.use(
+    http.get(`${BASE}/v1/call-transcripts/${id}`, ({ request }) => {
+      expect(request.headers.get('x-api-key')).toBe(API_KEY)
+      return HttpResponse.json(mock)
+    })
+  )
+
+  const { getCallTranscript } = await import('../src')
+  const res = await getCallTranscript(id)
+  expect(res).toEqual(mock)
+})
+
+test('updateCallTranscript sends patch with body', async () => {
+  const id = 'call2'
+  const body = { foo: 'bar' }
+  const mock = { ok: true }
+
+  server.use(
+    http.patch(`${BASE}/v1/call-transcripts/${id}`, async ({ request }) => {
+      expect(request.headers.get('x-api-key')).toBe(API_KEY)
+      expect(await request.json()).toEqual(body)
+      return HttpResponse.json(mock)
+    })
+  )
+
+  const { updateCallTranscript } = await import('../src')
+  const res = await updateCallTranscript(id, body)
+  expect(res).toEqual(mock)
+})
+
+test('deleteCallTranscript sends delete', async () => {
+  const id = 'call3'
+  const mock = { deleted: true }
+
+  server.use(
+    http.delete(`${BASE}/v1/call-transcripts/${id}`, ({ request }) => {
+      expect(request.headers.get('x-api-key')).toBe(API_KEY)
+      return HttpResponse.json(mock)
+    })
+  )
+
+  const { deleteCallTranscript } = await import('../src')
+  const res = await deleteCallTranscript(id)
+  expect(res).toEqual(mock)
+})

--- a/todo.md
+++ b/todo.md
@@ -1,7 +1,7 @@
 # Wrapper backlog
 - [x] 1. wrap `/v1/call-recordings/{callId}` (get, patch, delete) → `src/endpoints/call-recordings-by-id.ts`
 - [ ] 2. wrap `/v1/call-summaries/{callId}` (get, patch, delete) → `src/endpoints/call-summaries-by-id.ts`
-- [ ] 3. wrap `/v1/call-transcripts/{id}` (get, patch, delete) → `src/endpoints/call-transcripts-by-id.ts`
+- [x] 3. wrap `/v1/call-transcripts/{id}` (get, patch, delete) → `src/endpoints/call-transcripts-by-id.ts`
 - [ ] 4. wrap `/v1/calls` (get, post) → `src/endpoints/calls.ts`
 - [ ] 5. wrap `/v1/contact-custom-fields` (get, post) → `src/endpoints/contact-custom-fields.ts`
 - [ ] 6. wrap `/v1/contacts` (get, post) → `src/endpoints/contacts.ts`


### PR DESCRIPTION
## Summary
- wrap `/v1/call-transcripts/{id}` endpoint
- re-export the new functions
- test GET/PATCH/DELETE calls for call transcripts
- check the task off the backlog

## Testing
- `pnpm build`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685051728af48326a98e2abe0574e247