### PR TITLE
Implement contact custom fields wrapper

### DIFF
--- a/src/endpoints/contact-custom-fields.ts
+++ b/src/endpoints/contact-custom-fields.ts
@@ -1,0 +1,15 @@
+import { request } from '../request'
+import type { paths } from '../sdk'
+
+export type GetContactCustomFieldsResponse =
+  paths['/v1/contact-custom-fields']['get']['responses']['200']['content']['application/json']
+
+export async function getContactCustomFields() {
+  return request('/v1/contact-custom-fields', 'get')
+}
+
+export type CreateContactCustomFieldResponse = unknown
+
+export async function createContactCustomField(body: unknown): Promise<CreateContactCustomFieldResponse> {
+  return request('/v1/contact-custom-fields', 'post', { body } as any) as unknown as CreateContactCustomFieldResponse
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,9 @@ export {
   UpdateCallRecordingResponse,
   DeleteCallRecordingResponse,
 } from './endpoints/call-recordings-by-id'
+export {
+  getContactCustomFields,
+  createContactCustomField,
+  GetContactCustomFieldsResponse,
+  CreateContactCustomFieldResponse,
+} from './endpoints/contact-custom-fields'

--- a/tests/contact-custom-fields.test.ts
+++ b/tests/contact-custom-fields.test.ts
@@ -1,0 +1,46 @@
+import { afterAll, afterEach, beforeAll, expect, test } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+
+const BASE = 'https://api.openphone.com'
+const API_KEY = 'test-key'
+process.env.OPENPHONE_BASE_URL = BASE
+process.env.OPENPHONE_API_KEY = API_KEY
+
+const server = setupServer()
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+test('getContactCustomFields sends correct request', async () => {
+  const mock = { data: [] }
+
+  server.use(
+    http.get(`${BASE}/v1/contact-custom-fields`, ({ request }) => {
+      expect(request.headers.get('x-api-key')).toBe(API_KEY)
+      return HttpResponse.json(mock)
+    })
+  )
+
+  const { getContactCustomFields } = await import('../src')
+  const res = await getContactCustomFields()
+  expect(res).toEqual(mock)
+})
+
+test('createContactCustomField sends post with body', async () => {
+  const body = { foo: 'bar' }
+  const mock = { ok: true }
+
+  server.use(
+    http.post(`${BASE}/v1/contact-custom-fields`, async ({ request }) => {
+      expect(request.headers.get('x-api-key')).toBe(API_KEY)
+      expect(await request.json()).toEqual(body)
+      return HttpResponse.json(mock)
+    })
+  )
+
+  const { createContactCustomField } = await import('../src')
+  const res = await createContactCustomField(body)
+  expect(res).toEqual(mock)
+})

--- a/todo.md
+++ b/todo.md
@@ -3,7 +3,7 @@
 - [ ] 2. wrap `/v1/call-summaries/{callId}` (get, patch, delete) → `src/endpoints/call-summaries-by-id.ts`
 - [ ] 3. wrap `/v1/call-transcripts/{id}` (get, patch, delete) → `src/endpoints/call-transcripts-by-id.ts`
 - [ ] 4. wrap `/v1/calls` (get, post) → `src/endpoints/calls.ts`
-- [ ] 5. wrap `/v1/contact-custom-fields` (get, post) → `src/endpoints/contact-custom-fields.ts`
+- [x] 5. wrap `/v1/contact-custom-fields` (get, post) → `src/endpoints/contact-custom-fields.ts`
 - [ ] 6. wrap `/v1/contacts` (get, post) → `src/endpoints/contacts.ts`
 - [ ] 7. wrap `/v1/contacts/{id}` (get, patch, delete) → `src/endpoints/contacts-by-id.ts`
 - [ ] 8. wrap `/v1/conversations` (get, post) → `src/endpoints/conversations.ts`


### PR DESCRIPTION
## Summary
- add wrapper for `/v1/contact-custom-fields`
- export wrapper in index
- test GET and POST contact custom fields
- mark todo item complete

## Testing
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685051b88ea8832689b2a5b83cadaf60