### PR TITLE
Implement contacts endpoint wrappers

### DIFF
--- a/src/endpoints/contacts.ts
+++ b/src/endpoints/contacts.ts
@@ -1,0 +1,40 @@
+import { request } from '../request'
+import type { paths } from '../sdk'
+
+export type GetContactsResponse =
+  paths['/v1/contacts']['get']['responses']['200']['content']['application/json']
+
+export type ListContactsParams =
+  paths['/v1/contacts']['get']['parameters']['query']
+
+export async function getContacts(params: ListContactsParams) {
+  const query = new URLSearchParams()
+  for (const [key, value] of Object.entries(params)) {
+    if (Array.isArray(value)) {
+      for (const v of value) query.append(key, String(v))
+    } else if (value !== undefined && value !== null) {
+      query.append(key, String(value))
+    }
+  }
+  const q = query.toString()
+  return request(
+    (`/v1/contacts${q ? `?${q}` : ''}`) as unknown as '/v1/contacts',
+    'get'
+  )
+}
+
+export type CreateContactResponse =
+  paths['/v1/contacts']['post']['responses']['201']['content']['application/json']
+
+export type CreateContactBody =
+  paths['/v1/contacts']['post']['requestBody']['content']['application/json']
+
+export async function createContact(
+  body: CreateContactBody
+): Promise<CreateContactResponse> {
+  return request(
+    '/v1/contacts',
+    'post',
+    { body } as any
+  ) as Promise<CreateContactResponse>
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,11 @@ export {
   UpdateCallRecordingResponse,
   DeleteCallRecordingResponse,
 } from './endpoints/call-recordings-by-id'
+export {
+  getContacts,
+  createContact,
+  GetContactsResponse,
+  CreateContactResponse,
+  CreateContactBody,
+  ListContactsParams,
+} from './endpoints/contacts'

--- a/tests/contacts.test.ts
+++ b/tests/contacts.test.ts
@@ -1,0 +1,50 @@
+import { afterAll, afterEach, beforeAll, expect, test } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+
+const BASE = 'https://api.openphone.com'
+const API_KEY = 'test-key'
+process.env.OPENPHONE_BASE_URL = BASE
+process.env.OPENPHONE_API_KEY = API_KEY
+
+const server = setupServer()
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+const url = `${BASE}/v1/contacts`
+
+test('getContacts sends query params', async () => {
+  const params = { externalIds: ['a', 'b'], maxResults: 5 }
+  const mock = { data: [] }
+  server.use(
+    http.get(url, ({ request }) => {
+      expect(request.headers.get('x-api-key')).toBe(API_KEY)
+      const u = new URL(request.url)
+      expect(u.searchParams.getAll('externalIds')).toEqual(['a', 'b'])
+      expect(u.searchParams.get('maxResults')).toBe('5')
+      return HttpResponse.json(mock)
+    })
+  )
+
+  const { getContacts } = await import('../src')
+  const res = await getContacts(params as any)
+  expect(res).toEqual(mock)
+})
+
+test('createContact posts body', async () => {
+  const body = { defaultFields: { firstName: 'x' } }
+  const mock = { ok: true }
+  server.use(
+    http.post(url, async ({ request }) => {
+      expect(request.headers.get('x-api-key')).toBe(API_KEY)
+      expect(await request.json()).toEqual(body)
+      return HttpResponse.json(mock, { status: 201 })
+    })
+  )
+
+  const { createContact } = await import('../src')
+  const res = await createContact(body as any)
+  expect(res).toEqual(mock)
+})

--- a/todo.md
+++ b/todo.md
@@ -4,7 +4,7 @@
 - [ ] 3. wrap `/v1/call-transcripts/{id}` (get, patch, delete) → `src/endpoints/call-transcripts-by-id.ts`
 - [ ] 4. wrap `/v1/calls` (get, post) → `src/endpoints/calls.ts`
 - [ ] 5. wrap `/v1/contact-custom-fields` (get, post) → `src/endpoints/contact-custom-fields.ts`
-- [ ] 6. wrap `/v1/contacts` (get, post) → `src/endpoints/contacts.ts`
+- [x] 6. wrap `/v1/contacts` (get, post) → `src/endpoints/contacts.ts`
 - [ ] 7. wrap `/v1/contacts/{id}` (get, patch, delete) → `src/endpoints/contacts-by-id.ts`
 - [ ] 8. wrap `/v1/conversations` (get, post) → `src/endpoints/conversations.ts`
 - [ ] 9. wrap `/v1/messages` (get, post) → `src/endpoints/messages.ts`


### PR DESCRIPTION
## Summary
- add wrapper functions for `/v1/contacts`
- export new functions from index
- test contacts endpoints using msw
- mark todo item complete

## Testing
- `pnpm build`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685051cb51fc8326a6d6fff1310a3adf