### PR TITLE
Implement conversations endpoint wrapper

### DIFF
--- a/src/endpoints/conversations.ts
+++ b/src/endpoints/conversations.ts
@@ -1,0 +1,15 @@
+import { request } from '../request'
+import type { paths } from '../sdk'
+
+export type ListConversationsResponse =
+  paths['/v1/conversations']['get']['responses']['200']['content']['application/json']
+
+export async function listConversations() {
+  return request('/v1/conversations', 'get')
+}
+
+export type CreateConversationResponse = unknown
+
+export async function createConversation(body: unknown): Promise<CreateConversationResponse> {
+  return request('/v1/conversations', 'post', { body } as any) as unknown as CreateConversationResponse
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,9 @@ export {
   UpdateCallRecordingResponse,
   DeleteCallRecordingResponse,
 } from './endpoints/call-recordings-by-id'
+export {
+  listConversations,
+  createConversation,
+  ListConversationsResponse,
+  CreateConversationResponse,
+} from './endpoints/conversations'

--- a/tests/conversations.test.ts
+++ b/tests/conversations.test.ts
@@ -1,0 +1,46 @@
+import { afterAll, afterEach, beforeAll, expect, test } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+
+const BASE = 'https://api.openphone.com'
+const API_KEY = 'test-key'
+process.env.OPENPHONE_BASE_URL = BASE
+process.env.OPENPHONE_API_KEY = API_KEY
+
+const server = setupServer()
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+test('listConversations sends correct request', async () => {
+  const mock = { data: [] }
+
+  server.use(
+    http.get(`${BASE}/v1/conversations`, ({ request }) => {
+      expect(request.headers.get('x-api-key')).toBe(API_KEY)
+      return HttpResponse.json(mock)
+    })
+  )
+
+  const { listConversations } = await import('../src')
+  const res = await listConversations()
+  expect(res).toEqual(mock)
+})
+
+test('createConversation posts body', async () => {
+  const body = { foo: 'bar' }
+  const mock = { ok: true }
+
+  server.use(
+    http.post(`${BASE}/v1/conversations`, async ({ request }) => {
+      expect(request.headers.get('x-api-key')).toBe(API_KEY)
+      expect(await request.json()).toEqual(body)
+      return HttpResponse.json(mock)
+    })
+  )
+
+  const { createConversation } = await import('../src')
+  const res = await createConversation(body)
+  expect(res).toEqual(mock)
+})

--- a/todo.md
+++ b/todo.md
@@ -6,7 +6,7 @@
 - [ ] 5. wrap `/v1/contact-custom-fields` (get, post) → `src/endpoints/contact-custom-fields.ts`
 - [ ] 6. wrap `/v1/contacts` (get, post) → `src/endpoints/contacts.ts`
 - [ ] 7. wrap `/v1/contacts/{id}` (get, patch, delete) → `src/endpoints/contacts-by-id.ts`
-- [ ] 8. wrap `/v1/conversations` (get, post) → `src/endpoints/conversations.ts`
+- [x] 8. wrap `/v1/conversations` (get, post) → `src/endpoints/conversations.ts`
 - [ ] 9. wrap `/v1/messages` (get, post) → `src/endpoints/messages.ts`
 - [ ] 10. wrap `/v1/messages/{id}` (get, patch, delete) → `src/endpoints/messages-by-id.ts`
 - [ ] 11. wrap `/v1/phone-numbers` (get, post) → `src/endpoints/phone-numbers.ts`


### PR DESCRIPTION
## Summary
- add `conversations` wrappers
- export wrappers from index
- add unit tests for new wrappers
- mark conversations wrapper task complete in TODO

## Testing
- `pnpm build`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685051e5183c8326b0ddf1a7de6b3a28