### PR TITLE
Implement /v1/messages wrappers

### DIFF
--- a/src/endpoints/messages.ts
+++ b/src/endpoints/messages.ts
@@ -1,0 +1,31 @@
+import { request } from '../request'
+import type { paths } from '../sdk'
+
+export type ListMessagesResponse =
+  paths['/v1/messages']['get']['responses']['200']['content']['application/json']
+
+export async function listMessages(
+  query: paths['/v1/messages']['get']['parameters']['query']
+): Promise<ListMessagesResponse> {
+  const params = new URLSearchParams()
+  params.set('phoneNumberId', query.phoneNumberId)
+  if (query.userId) params.set('userId', query.userId)
+  for (const p of query.participants) params.append('participants', p)
+  if (query.since) params.set('since', query.since)
+  if (query.createdAfter) params.set('createdAfter', query.createdAfter)
+  if (query.createdBefore) params.set('createdBefore', query.createdBefore)
+  params.set('maxResults', String(query.maxResults))
+  if (query.pageToken) params.set('pageToken', query.pageToken)
+
+  const path = (`/v1/messages?${params.toString()}`) as unknown as '/v1/messages'
+  return request(path, 'get') as unknown as ListMessagesResponse
+}
+
+export type SendMessageResponse =
+  paths['/v1/messages']['post']['responses']['202']['content']['application/json']
+
+export async function sendMessage(
+  body: paths['/v1/messages']['post']['requestBody']['content']['application/json']
+): Promise<SendMessageResponse> {
+  return request('/v1/messages', 'post', { body } as any) as unknown as SendMessageResponse
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,10 @@ export {
   UpdateCallRecordingResponse,
   DeleteCallRecordingResponse,
 } from './endpoints/call-recordings-by-id'
+
+export {
+  listMessages,
+  sendMessage,
+  ListMessagesResponse,
+  SendMessageResponse,
+} from './endpoints/messages'

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -1,0 +1,59 @@
+import { afterAll, afterEach, beforeAll, expect, test } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+
+const BASE = 'https://api.openphone.com'
+const API_KEY = 'test-key'
+process.env.OPENPHONE_BASE_URL = BASE
+process.env.OPENPHONE_API_KEY = API_KEY
+
+const server = setupServer()
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+test('listMessages sends correct query', async () => {
+  const query = {
+    phoneNumberId: 'PN1',
+    participants: ['+15551234567'],
+    maxResults: 10,
+  }
+  const mock = { data: [], totalItems: 0, nextPageToken: null }
+
+  server.use(
+    http.get(`${BASE}/v1/messages`, ({ request }) => {
+      const url = new URL(request.url)
+      expect(request.headers.get('x-api-key')).toBe(API_KEY)
+      expect(url.searchParams.get('phoneNumberId')).toBe(query.phoneNumberId)
+      expect(url.searchParams.getAll('participants')).toEqual(query.participants)
+      expect(url.searchParams.get('maxResults')).toBe(String(query.maxResults))
+      return HttpResponse.json(mock)
+    })
+  )
+
+  const { listMessages } = await import('../src')
+  const res = await listMessages(query as any)
+  expect(res).toEqual(mock)
+})
+
+test('sendMessage posts body', async () => {
+  const body = {
+    content: 'hi',
+    from: 'PN1',
+    to: ['+15551234567'],
+  }
+  const mock = { data: { id: 'm1' } }
+
+  server.use(
+    http.post(`${BASE}/v1/messages`, async ({ request }) => {
+      expect(request.headers.get('x-api-key')).toBe(API_KEY)
+      expect(await request.json()).toEqual(body)
+      return HttpResponse.json(mock, { status: 202 })
+    })
+  )
+
+  const { sendMessage } = await import('../src')
+  const res = await sendMessage(body as any)
+  expect(res).toEqual(mock)
+})

--- a/todo.md
+++ b/todo.md
@@ -7,7 +7,7 @@
 - [ ] 6. wrap `/v1/contacts` (get, post) → `src/endpoints/contacts.ts`
 - [ ] 7. wrap `/v1/contacts/{id}` (get, patch, delete) → `src/endpoints/contacts-by-id.ts`
 - [ ] 8. wrap `/v1/conversations` (get, post) → `src/endpoints/conversations.ts`
-- [ ] 9. wrap `/v1/messages` (get, post) → `src/endpoints/messages.ts`
+- [x] 9. wrap `/v1/messages` (get, post) → `src/endpoints/messages.ts`
 - [ ] 10. wrap `/v1/messages/{id}` (get, patch, delete) → `src/endpoints/messages-by-id.ts`
 - [ ] 11. wrap `/v1/phone-numbers` (get, post) → `src/endpoints/phone-numbers.ts`
 - [ ] 12. wrap `/v1/webhooks` (get, post) → `src/endpoints/webhooks.ts`


### PR DESCRIPTION
## Summary
- add wrappers for `/v1/messages` GET and POST endpoints
- export new wrapper functions
- test messages wrappers with msw
- mark TODO item as complete

## Testing
- `pnpm build`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685051fda1cc8326b9aae944c316e01d