### PR TITLE
Add phone numbers wrapper

### DIFF
--- a/src/endpoints/phone-numbers.ts
+++ b/src/endpoints/phone-numbers.ts
@@ -1,0 +1,25 @@
+import { request } from '../request'
+import type { paths } from '../sdk'
+
+export type ListPhoneNumbersResponse =
+  paths['/v1/phone-numbers']['get']['responses']['200']['content']['application/json']
+
+export async function listPhoneNumbers(userId?: string) {
+  const query = userId ? `?userId=${userId}` : ''
+  return request(
+    `/v1/phone-numbers${query}` as unknown as '/v1/phone-numbers',
+    'get'
+  )
+}
+
+export type CreatePhoneNumberResponse = unknown
+
+export async function createPhoneNumber(
+  body: unknown
+): Promise<CreatePhoneNumberResponse> {
+  return request(
+    '/v1/phone-numbers',
+    'post',
+    { body } as any
+  ) as unknown as CreatePhoneNumberResponse
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,9 @@ export {
   UpdateCallRecordingResponse,
   DeleteCallRecordingResponse,
 } from './endpoints/call-recordings-by-id'
+export {
+  listPhoneNumbers,
+  createPhoneNumber,
+  ListPhoneNumbersResponse,
+  CreatePhoneNumberResponse,
+} from './endpoints/phone-numbers'

--- a/tests/phone-numbers.test.ts
+++ b/tests/phone-numbers.test.ts
@@ -1,0 +1,47 @@
+import { afterAll, afterEach, beforeAll, expect, test } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+
+const BASE = 'https://api.openphone.com'
+const API_KEY = 'test-key'
+process.env.OPENPHONE_BASE_URL = BASE
+process.env.OPENPHONE_API_KEY = API_KEY
+
+const server = setupServer()
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+test('listPhoneNumbers sends correct request', async () => {
+  const mock = { data: [] }
+  const userId = 'US123'
+
+  server.use(
+    http.get(`${BASE}/v1/phone-numbers?userId=${userId}`, ({ request }) => {
+      expect(request.headers.get('x-api-key')).toBe(API_KEY)
+      return HttpResponse.json(mock)
+    })
+  )
+
+  const { listPhoneNumbers } = await import('../src')
+  const res = await listPhoneNumbers(userId)
+  expect(res).toEqual(mock)
+})
+
+test('createPhoneNumber posts body', async () => {
+  const body = { foo: 'bar' }
+  const mock = { ok: true }
+
+  server.use(
+    http.post(`${BASE}/v1/phone-numbers`, async ({ request }) => {
+      expect(request.headers.get('x-api-key')).toBe(API_KEY)
+      expect(await request.json()).toEqual(body)
+      return HttpResponse.json(mock)
+    })
+  )
+
+  const { createPhoneNumber } = await import('../src')
+  const res = await createPhoneNumber(body)
+  expect(res).toEqual(mock)
+})

--- a/todo.md
+++ b/todo.md
@@ -9,7 +9,7 @@
 - [ ] 8. wrap `/v1/conversations` (get, post) → `src/endpoints/conversations.ts`
 - [ ] 9. wrap `/v1/messages` (get, post) → `src/endpoints/messages.ts`
 - [ ] 10. wrap `/v1/messages/{id}` (get, patch, delete) → `src/endpoints/messages-by-id.ts`
-- [ ] 11. wrap `/v1/phone-numbers` (get, post) → `src/endpoints/phone-numbers.ts`
+- [x] 11. wrap `/v1/phone-numbers` (get, post) → `src/endpoints/phone-numbers.ts`
 - [ ] 12. wrap `/v1/webhooks` (get, post) → `src/endpoints/webhooks.ts`
 - [ ] 13. wrap `/v1/webhooks/call-summaries` (get, post) → `src/endpoints/webhooks-call-summaries.ts`
 - [ ] 14. wrap `/v1/webhooks/call-transcripts` (get, post) → `src/endpoints/webhooks-call-transcripts.ts`


### PR DESCRIPTION
## Summary
- wrap `/v1/phone-numbers` GET and POST endpoints
- export wrappers from index
- test new wrappers with msw
- mark phone numbers task complete in todo

## Testing
- `pnpm run build`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6850521e0538832688a6911a4a58804f