### PR TITLE
Add webhooks call summaries endpoint

### DIFF
--- a/src/endpoints/webhooks-call-summaries.ts
+++ b/src/endpoints/webhooks-call-summaries.ts
@@ -1,0 +1,21 @@
+import { request } from '../request'
+import type { paths } from '../sdk'
+
+export type ListCallSummaryWebhooksResponse = unknown
+
+export async function listCallSummaryWebhooks(): Promise<ListCallSummaryWebhooksResponse> {
+  return request('/v1/webhooks/call-summaries' as any, 'get') as unknown as ListCallSummaryWebhooksResponse
+}
+
+export type CreateCallSummaryWebhookResponse =
+  paths['/v1/webhooks/call-summaries']['post']['responses']['201']['content']['application/json']
+
+export async function createCallSummaryWebhook(
+  body: paths['/v1/webhooks/call-summaries']['post']['requestBody']['content']['application/json']
+): Promise<CreateCallSummaryWebhookResponse> {
+  return request(
+    '/v1/webhooks/call-summaries',
+    'post',
+    { body } as any
+  ) as unknown as CreateCallSummaryWebhookResponse
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,10 @@ export {
   UpdateCallRecordingResponse,
   DeleteCallRecordingResponse,
 } from './endpoints/call-recordings-by-id'
+
+export {
+  listCallSummaryWebhooks,
+  createCallSummaryWebhook,
+  ListCallSummaryWebhooksResponse,
+  CreateCallSummaryWebhookResponse,
+} from './endpoints/webhooks-call-summaries'

--- a/tests/webhooks-call-summaries.test.ts
+++ b/tests/webhooks-call-summaries.test.ts
@@ -1,0 +1,46 @@
+import { afterAll, afterEach, beforeAll, expect, test } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+
+const BASE = 'https://api.openphone.com'
+const API_KEY = 'test-key'
+process.env.OPENPHONE_BASE_URL = BASE
+process.env.OPENPHONE_API_KEY = API_KEY
+
+const server = setupServer()
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+test('listCallSummaryWebhooks sends correct request', async () => {
+  const mock = { data: [] }
+
+  server.use(
+    http.get(`${BASE}/v1/webhooks/call-summaries`, ({ request }) => {
+      expect(request.headers.get('x-api-key')).toBe(API_KEY)
+      return HttpResponse.json(mock)
+    })
+  )
+
+  const { listCallSummaryWebhooks } = await import('../src')
+  const res = await listCallSummaryWebhooks()
+  expect(res).toEqual(mock)
+})
+
+test('createCallSummaryWebhook sends post with body', async () => {
+  const body = { events: ['call.summary.completed'], url: 'https://example.com' }
+  const mock = { ok: true }
+
+  server.use(
+    http.post(`${BASE}/v1/webhooks/call-summaries`, async ({ request }) => {
+      expect(request.headers.get('x-api-key')).toBe(API_KEY)
+      expect(await request.json()).toEqual(body)
+      return HttpResponse.json(mock, { status: 201 })
+    })
+  )
+
+  const { createCallSummaryWebhook } = await import('../src')
+  const res = await createCallSummaryWebhook(body as any)
+  expect(res).toEqual(mock)
+})

--- a/todo.md
+++ b/todo.md
@@ -11,7 +11,7 @@
 - [ ] 10. wrap `/v1/messages/{id}` (get, patch, delete) → `src/endpoints/messages-by-id.ts`
 - [ ] 11. wrap `/v1/phone-numbers` (get, post) → `src/endpoints/phone-numbers.ts`
 - [ ] 12. wrap `/v1/webhooks` (get, post) → `src/endpoints/webhooks.ts`
-- [ ] 13. wrap `/v1/webhooks/call-summaries` (get, post) → `src/endpoints/webhooks-call-summaries.ts`
+- [x] 13. wrap `/v1/webhooks/call-summaries` (get, post) → `src/endpoints/webhooks-call-summaries.ts`
 - [ ] 14. wrap `/v1/webhooks/call-transcripts` (get, post) → `src/endpoints/webhooks-call-transcripts.ts`
 - [ ] 15. wrap `/v1/webhooks/calls` (get, post) → `src/endpoints/webhooks-calls.ts`
 - [ ] 16. wrap `/v1/webhooks/messages` (get, post) → `src/endpoints/webhooks-messages.ts`


### PR DESCRIPTION
## Summary
- add `webhooks-call-summaries` endpoint wrapper
- export new functions from index
- test list/create webhook wrappers
- check off corresponding todo item

## Testing
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6850525d032c8326983de3783242c931