### PR TITLE
Add webhook call transcript wrappers

### DIFF
--- a/src/endpoints/webhooks-call-transcripts.ts
+++ b/src/endpoints/webhooks-call-transcripts.ts
@@ -1,0 +1,24 @@
+import { request } from '../request'
+import type { paths } from '../sdk'
+
+export type GetCallTranscriptWebhooksResponse = unknown
+
+export async function getCallTranscriptWebhooks() {
+  return request(
+    '/v1/webhooks/call-transcripts' as `/v1/webhooks/call-transcripts`,
+    'get'
+  ) as unknown as GetCallTranscriptWebhooksResponse
+}
+
+export type CreateCallTranscriptWebhookResponse =
+  paths['/v1/webhooks/call-transcripts']['post']['responses']['201']['content']['application/json']
+
+export async function createCallTranscriptWebhook(
+  body: paths['/v1/webhooks/call-transcripts']['post']['requestBody']['content']['application/json']
+) {
+  return request(
+    '/v1/webhooks/call-transcripts',
+    'post',
+    { body } as any
+  ) as Promise<CreateCallTranscriptWebhookResponse>
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,9 @@ export {
   UpdateCallRecordingResponse,
   DeleteCallRecordingResponse,
 } from './endpoints/call-recordings-by-id'
+export {
+  getCallTranscriptWebhooks,
+  createCallTranscriptWebhook,
+  GetCallTranscriptWebhooksResponse,
+  CreateCallTranscriptWebhookResponse,
+} from './endpoints/webhooks-call-transcripts'

--- a/tests/webhooks-call-transcripts.test.ts
+++ b/tests/webhooks-call-transcripts.test.ts
@@ -1,0 +1,47 @@
+import { afterAll, afterEach, beforeAll, expect, test } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+
+const BASE = 'https://api.openphone.com'
+const API_KEY = 'test-key'
+process.env.OPENPHONE_BASE_URL = BASE
+process.env.OPENPHONE_API_KEY = API_KEY
+
+const server = setupServer()
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+
+test('getCallTranscriptWebhooks sends correct request', async () => {
+  const mock = { data: [] }
+
+  server.use(
+    http.get(`${BASE}/v1/webhooks/call-transcripts`, ({ request }) => {
+      expect(request.headers.get('x-api-key')).toBe(API_KEY)
+      return HttpResponse.json(mock)
+    })
+  )
+
+  const { getCallTranscriptWebhooks } = await import('../src')
+  const res = await getCallTranscriptWebhooks()
+  expect(res).toEqual(mock)
+})
+
+test('createCallTranscriptWebhook posts body', async () => {
+  const body = { events: ['call.transcript.completed'], url: 'https://ex.com' }
+  const mock = { ok: true }
+
+  server.use(
+    http.post(`${BASE}/v1/webhooks/call-transcripts`, async ({ request }) => {
+      expect(request.headers.get('x-api-key')).toBe(API_KEY)
+      expect(await request.json()).toEqual(body)
+      return HttpResponse.json(mock, { status: 201 })
+    })
+  )
+
+  const { createCallTranscriptWebhook } = await import('../src')
+  const res = await createCallTranscriptWebhook(body as any)
+  expect(res).toEqual(mock)
+})

--- a/todo.md
+++ b/todo.md
@@ -12,7 +12,7 @@
 - [ ] 11. wrap `/v1/phone-numbers` (get, post) → `src/endpoints/phone-numbers.ts`
 - [ ] 12. wrap `/v1/webhooks` (get, post) → `src/endpoints/webhooks.ts`
 - [ ] 13. wrap `/v1/webhooks/call-summaries` (get, post) → `src/endpoints/webhooks-call-summaries.ts`
-- [ ] 14. wrap `/v1/webhooks/call-transcripts` (get, post) → `src/endpoints/webhooks-call-transcripts.ts`
+- [x] 14. wrap `/v1/webhooks/call-transcripts` (get, post) → `src/endpoints/webhooks-call-transcripts.ts`
 - [ ] 15. wrap `/v1/webhooks/calls` (get, post) → `src/endpoints/webhooks-calls.ts`
 - [ ] 16. wrap `/v1/webhooks/messages` (get, post) → `src/endpoints/webhooks-messages.ts`
 - [ ] 17. wrap `/v1/webhooks/{id}` (get, patch, delete) → `src/endpoints/webhooks-by-id.ts`


### PR DESCRIPTION
## Summary
- wrap `/v1/webhooks/call-transcripts` GET and POST endpoints
- export new webhook helpers
- test webhook transcript helpers
- check off task 14 in todo

## Testing
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685052735c7c8326811e2a2aa9c0605e