### PR TITLE
Add webhooks calls wrappers

### DIFF
--- a/src/endpoints/webhooks-calls.ts
+++ b/src/endpoints/webhooks-calls.ts
@@ -1,0 +1,18 @@
+import { request } from '../request'
+import type { paths } from '../sdk'
+
+export type ListCallWebhooksResponse = unknown
+
+export async function listCallWebhooks() {
+  return request('/v1/webhooks/calls', 'get')
+}
+
+export type CreateCallWebhookBody =
+  paths['/v1/webhooks/calls']['post']['requestBody']['content']['application/json']
+
+export type CreateCallWebhookResponse =
+  paths['/v1/webhooks/calls']['post']['responses']['201']['content']['application/json']
+
+export async function createCallWebhook(body: CreateCallWebhookBody) {
+  return request('/v1/webhooks/calls', 'post', { body } as any)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,10 @@ export {
   UpdateCallRecordingResponse,
   DeleteCallRecordingResponse,
 } from './endpoints/call-recordings-by-id'
+export {
+  listCallWebhooks,
+  createCallWebhook,
+  ListCallWebhooksResponse,
+  CreateCallWebhookBody,
+  CreateCallWebhookResponse,
+} from './endpoints/webhooks-calls'

--- a/tests/webhooks-calls.test.ts
+++ b/tests/webhooks-calls.test.ts
@@ -1,0 +1,46 @@
+import { afterAll, afterEach, beforeAll, expect, test } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+
+const BASE = 'https://api.openphone.com'
+const API_KEY = 'test-key'
+process.env.OPENPHONE_BASE_URL = BASE
+process.env.OPENPHONE_API_KEY = API_KEY
+
+const server = setupServer()
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+test('listCallWebhooks sends correct request', async () => {
+  const mock = { data: [] }
+
+  server.use(
+    http.get(`${BASE}/v1/webhooks/calls`, ({ request }) => {
+      expect(request.headers.get('x-api-key')).toBe(API_KEY)
+      return HttpResponse.json(mock)
+    })
+  )
+
+  const { listCallWebhooks } = await import('../src')
+  const res = await listCallWebhooks()
+  expect(res).toEqual(mock)
+})
+
+test('createCallWebhook sends post with body', async () => {
+  const body = { url: 'https://example.com', events: ['call.ringing'] }
+  const mock = { data: { id: 'wh1' } }
+
+  server.use(
+    http.post(`${BASE}/v1/webhooks/calls`, async ({ request }) => {
+      expect(request.headers.get('x-api-key')).toBe(API_KEY)
+      expect(await request.json()).toEqual(body)
+      return HttpResponse.json(mock, { status: 201 })
+    })
+  )
+
+  const { createCallWebhook } = await import('../src')
+  const res = await createCallWebhook(body as any)
+  expect(res).toEqual(mock)
+})

--- a/todo.md
+++ b/todo.md
@@ -13,6 +13,6 @@
 - [ ] 12. wrap `/v1/webhooks` (get, post) → `src/endpoints/webhooks.ts`
 - [ ] 13. wrap `/v1/webhooks/call-summaries` (get, post) → `src/endpoints/webhooks-call-summaries.ts`
 - [ ] 14. wrap `/v1/webhooks/call-transcripts` (get, post) → `src/endpoints/webhooks-call-transcripts.ts`
-- [ ] 15. wrap `/v1/webhooks/calls` (get, post) → `src/endpoints/webhooks-calls.ts`
+- [x] 15. wrap `/v1/webhooks/calls` (get, post) → `src/endpoints/webhooks-calls.ts`
 - [ ] 16. wrap `/v1/webhooks/messages` (get, post) → `src/endpoints/webhooks-messages.ts`
 - [ ] 17. wrap `/v1/webhooks/{id}` (get, patch, delete) → `src/endpoints/webhooks-by-id.ts`


### PR DESCRIPTION
## Summary
- implement client wrappers for `/v1/webhooks/calls`
- export new wrappers
- test the new wrappers with msw
- check off todo item for this wrapper

## Testing
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6850528c09b48326a55182ecf92d54db