### PR TITLE
Add webhooks/{id} endpoint wrappers

### DIFF
--- a/src/endpoints/webhooks-by-id.ts
+++ b/src/endpoints/webhooks-by-id.ts
@@ -1,0 +1,34 @@
+import { request } from '../request'
+import type { paths } from '../sdk'
+
+export type GetWebhookResponse =
+  paths['/v1/webhooks/{id}']['get']['responses']['200']['content']['application/json']
+
+export async function getWebhook(id: string): Promise<GetWebhookResponse> {
+  return request(
+    `/v1/webhooks/${id}` as `/v1/webhooks/{id}`,
+    'get'
+  ) as unknown as GetWebhookResponse
+}
+
+export type UpdateWebhookResponse = unknown
+
+export async function updateWebhook(
+  id: string,
+  body: unknown
+): Promise<UpdateWebhookResponse> {
+  return request(
+    `/v1/webhooks/${id}` as unknown as `/v1/webhooks/{id}`,
+    'patch',
+    { body } as any
+  ) as unknown as UpdateWebhookResponse
+}
+
+export type DeleteWebhookResponse = unknown
+
+export async function deleteWebhook(id: string): Promise<DeleteWebhookResponse> {
+  return request(
+    `/v1/webhooks/${id}` as unknown as `/v1/webhooks/{id}`,
+    'delete'
+  ) as unknown as DeleteWebhookResponse
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,12 @@ export {
   UpdateCallRecordingResponse,
   DeleteCallRecordingResponse,
 } from './endpoints/call-recordings-by-id'
+
+export {
+  getWebhook,
+  updateWebhook,
+  deleteWebhook,
+  GetWebhookResponse,
+  UpdateWebhookResponse,
+  DeleteWebhookResponse,
+} from './endpoints/webhooks-by-id'

--- a/tests/webhooks-by-id.test.ts
+++ b/tests/webhooks-by-id.test.ts
@@ -1,0 +1,64 @@
+import { afterAll, afterEach, beforeAll, expect, test } from 'vitest'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+
+const BASE = 'https://api.openphone.com'
+const API_KEY = 'test-key'
+process.env.OPENPHONE_BASE_URL = BASE
+process.env.OPENPHONE_API_KEY = API_KEY
+
+const server = setupServer()
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+test('getWebhook sends correct request', async () => {
+  const id = 'wh1'
+  const mock = { data: { id } }
+
+  server.use(
+    http.get(`${BASE}/v1/webhooks/${id}`, ({ request }) => {
+      expect(request.headers.get('x-api-key')).toBe(API_KEY)
+      return HttpResponse.json(mock)
+    })
+  )
+
+  const { getWebhook } = await import('../src')
+  const res = await getWebhook(id)
+  expect(res).toEqual(mock)
+})
+
+test('updateWebhook sends patch with body', async () => {
+  const id = 'wh2'
+  const body = { label: 'test' }
+  const mock = { ok: true }
+
+  server.use(
+    http.patch(`${BASE}/v1/webhooks/${id}`, async ({ request }) => {
+      expect(request.headers.get('x-api-key')).toBe(API_KEY)
+      expect(await request.json()).toEqual(body)
+      return HttpResponse.json(mock)
+    })
+  )
+
+  const { updateWebhook } = await import('../src')
+  const res = await updateWebhook(id, body)
+  expect(res).toEqual(mock)
+})
+
+test('deleteWebhook sends delete', async () => {
+  const id = 'wh3'
+  const mock = { deleted: true }
+
+  server.use(
+    http.delete(`${BASE}/v1/webhooks/${id}`, ({ request }) => {
+      expect(request.headers.get('x-api-key')).toBe(API_KEY)
+      return HttpResponse.json(mock)
+    })
+  )
+
+  const { deleteWebhook } = await import('../src')
+  const res = await deleteWebhook(id)
+  expect(res).toEqual(mock)
+})

--- a/todo.md
+++ b/todo.md
@@ -15,4 +15,4 @@
 - [ ] 14. wrap `/v1/webhooks/call-transcripts` (get, post) → `src/endpoints/webhooks-call-transcripts.ts`
 - [ ] 15. wrap `/v1/webhooks/calls` (get, post) → `src/endpoints/webhooks-calls.ts`
 - [ ] 16. wrap `/v1/webhooks/messages` (get, post) → `src/endpoints/webhooks-messages.ts`
-- [ ] 17. wrap `/v1/webhooks/{id}` (get, patch, delete) → `src/endpoints/webhooks-by-id.ts`
+- [x] 17. wrap `/v1/webhooks/{id}` (get, patch, delete) → `src/endpoints/webhooks-by-id.ts`


### PR DESCRIPTION
## Summary
- implement wrappers for `/v1/webhooks/{id}`
- expose webhooks helpers from index
- test new wrappers
- mark todo

## Testing
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685052bd71148326a60eb778f9584c49